### PR TITLE
Fix: Preserve unsubmitted input text during history navigation

### DIFF
--- a/cmd/agents/interactive.go
+++ b/cmd/agents/interactive.go
@@ -280,6 +280,7 @@ type model struct {
 	messages    []string
 	history     []string
 	historyIdx  int
+	currentInput string
 	manager     sdk.AgentManager
 	err         error
 	width       int
@@ -801,6 +802,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			if m.textArea.Line() == 0 {
 				if len(m.history) > 0 && m.historyIdx > 0 {
+					if m.historyIdx == len(m.history) {
+						m.currentInput = m.textArea.Value()
+					}
 					m.historyIdx--
 					m.textArea.SetValue(m.history[m.historyIdx])
 					m.textArea.CursorEnd()
@@ -821,7 +825,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if len(m.history) > 0 && m.historyIdx < len(m.history) {
 					m.historyIdx++
 					if m.historyIdx == len(m.history) {
-						m.textArea.Reset()
+						m.textArea.SetValue(m.currentInput)
+						m.textArea.CursorEnd()
 					} else {
 						m.textArea.SetValue(m.history[m.historyIdx])
 						m.textArea.CursorEnd()

--- a/cmd/agents/interactive_test.go
+++ b/cmd/agents/interactive_test.go
@@ -75,3 +75,62 @@ func TestSnapshotFileAutocomplete(t *testing.T) {
 	fmt.Println(rawView)
 	fmt.Println("=== END TUI FILE AUTOCOMPLETE SNAPSHOT ===")
 }
+
+func TestHistoryNavigation(t *testing.T) {
+	m := initialModel(false, false)
+	m.history = []string{"first command", "second command"}
+	m.historyIdx = 2
+
+	// 1. Type something unsubmitted
+	unsubmitted := "unsubmitted text"
+	for _, r := range unsubmitted {
+		newModel, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		m = newModel.(model)
+	}
+	if m.textArea.Value() != unsubmitted {
+		t.Errorf("expected text area value %q, got %q", unsubmitted, m.textArea.Value())
+	}
+
+	// 2. Press Up arrow
+	newModel, _ := m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	m = newModel.(model)
+	if m.textArea.Value() != "second command" {
+		t.Errorf("expected text area value %q, got %q", "second command", m.textArea.Value())
+	}
+	if m.historyIdx != 1 {
+		t.Errorf("expected historyIdx 1, got %d", m.historyIdx)
+	}
+	if m.currentInput != unsubmitted {
+		t.Errorf("expected currentInput %q, got %q", unsubmitted, m.currentInput)
+	}
+
+	// 3. Press Up arrow again
+	newModel, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	m = newModel.(model)
+	if m.textArea.Value() != "first command" {
+		t.Errorf("expected text area value %q, got %q", "first command", m.textArea.Value())
+	}
+	if m.historyIdx != 0 {
+		t.Errorf("expected historyIdx 0, got %d", m.historyIdx)
+	}
+
+	// 4. Press Down arrow
+	newModel, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = newModel.(model)
+	if m.textArea.Value() != "second command" {
+		t.Errorf("expected text area value %q, got %q", "second command", m.textArea.Value())
+	}
+	if m.historyIdx != 1 {
+		t.Errorf("expected historyIdx 1, got %d", m.historyIdx)
+	}
+
+	// 5. Press Down arrow again to return to unsubmitted
+	newModel, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = newModel.(model)
+	if m.historyIdx != 2 {
+		t.Errorf("expected historyIdx 2, got %d", m.historyIdx)
+	}
+	if m.textArea.Value() != unsubmitted {
+		t.Errorf("expected text area value %q, got %q", unsubmitted, m.textArea.Value())
+	}
+}


### PR DESCRIPTION
This PR fixes Issue #4. It ensures that any unsubmitted input text in the prompt is preserved when the user navigates through their command history using the Up and Down arrows, and restored when they return to the current prompt.

Fixes #4