### PR TITLE
Fix #9: Update status bar dynamically to reflect git branch and dirty status

### DIFF
--- a/cmd/agents/interactive.go
+++ b/cmd/agents/interactive.go
@@ -9,6 +9,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"runtime/debug"
+	"time"
 
 	"strings"
 
@@ -275,27 +276,27 @@ func getWorkspaceFiles() []string {
 }
 
 type model struct {
-	textArea    textarea.Model
-	viewport    viewport.Model
-	spinner     spinner.Model
-	listModel   list.Model
-	messages    []string
-	history     []string
-	historyIdx  int
+	textArea     textarea.Model
+	viewport     viewport.Model
+	spinner      spinner.Model
+	listModel    list.Model
+	messages     []string
+	history      []string
+	historyIdx   int
 	currentInput string
-	manager     sdk.AgentManager
-	err         error
-	width       int
-	height      int
-	loading     bool
-	quitting    bool
-	planMode    bool
-	state       uiState
-	cwd         string
-	gitBranch   string
-	gitModified bool
-	activeModel string
-	renderer    *glamour.TermRenderer
+	manager      sdk.AgentManager
+	err          error
+	width        int
+	height       int
+	loading      bool
+	quitting     bool
+	planMode     bool
+	state        uiState
+	cwd          string
+	gitBranch    string
+	gitModified  bool
+	activeModel  string
+	renderer     *glamour.TermRenderer
 
 	statusMsg    string
 	lastResponse string
@@ -501,21 +502,31 @@ func saveHistory(history []string) {
 }
 
 func getGitInfo() (string, bool) {
-	cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
-	out, err := cmd.Output()
+	info, err := sdk.GetGitInfo(".")
 	if err != nil {
 		return "", false
 	}
-	branch := strings.TrimSpace(string(out))
+	return info.Branch, info.Modified
+}
 
-	cmd = exec.Command("git", "status", "--porcelain")
-	out, err = cmd.Output()
-	modified := false
-	if err == nil && len(strings.TrimSpace(string(out))) > 0 {
-		modified = true
+type gitStatusMsg struct {
+	branch   string
+	modified bool
+}
+
+func checkGitStatus() tea.Cmd {
+	return func() tea.Msg {
+		branch, modified := getGitInfo()
+		return gitStatusMsg{branch, modified}
 	}
+}
 
-	return branch, modified
+type gitTickMsg time.Time
+
+func doGitTick() tea.Cmd {
+	return tea.Tick(time.Second*10, func(t time.Time) tea.Msg {
+		return gitTickMsg(t)
+	})
 }
 
 func initialModel(planMode bool, resume bool) model {
@@ -596,7 +607,7 @@ func initialModel(planMode bool, resume bool) model {
 }
 
 func (m model) Init() tea.Cmd {
-	return tea.Batch(textarea.Blink, m.spinner.Tick)
+	return tea.Batch(textarea.Blink, m.spinner.Tick, doGitTick())
 }
 
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -679,6 +690,14 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	switch msg := msg.(type) {
+	case gitStatusMsg:
+		m.gitBranch = msg.branch
+		m.gitModified = msg.modified
+		return m, nil
+
+	case gitTickMsg:
+		return m, tea.Batch(checkGitStatus(), doGitTick())
+
 	case tea.KeyMsg:
 		switch msg.Type {
 		case tea.KeyEsc:
@@ -888,14 +907,14 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.loading = false
 		m.statusMsg = ""
 		m.updateViewport()
-		return m, nil
+		return m, checkGitStatus()
 
 	case streamErrMsg:
 		m.loading = false
 		m.statusMsg = ""
 		m.messages = append(m.messages, lipgloss.NewStyle().Foreground(errorColor).Width(m.viewport.Width).Render("Error: "+msg.err.Error()))
 		m.updateViewport()
-		return m, nil
+		return m, checkGitStatus()
 
 	case responseMsg:
 		m.loading = false
@@ -915,7 +934,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.messages = append(m.messages, agentMsgStyle.Render("✦\n")+strings.TrimSpace(out))
 		}
 		m.updateViewport()
-		return m, nil
+		return m, checkGitStatus()
 
 	case modelsLoadedMsg:
 		m.loading = false

--- a/cmd/agents/interactive_test.go
+++ b/cmd/agents/interactive_test.go
@@ -134,3 +134,75 @@ func TestHistoryNavigation(t *testing.T) {
 		t.Errorf("expected text area value %q, got %q", unsubmitted, m.textArea.Value())
 	}
 }
+
+func TestGitStatusUpdate(t *testing.T) {
+	m := initialModel(false, false)
+
+	// Initial state
+	m.gitBranch = "old-branch"
+	m.gitModified = false
+
+	// Simulate gitStatusMsg
+	newBranch := "new-feature"
+	newModified := true
+	msg := gitStatusMsg{
+		branch:   newBranch,
+		modified: newModified,
+	}
+
+	newModel, cmd := m.Update(msg)
+	m = newModel.(model)
+
+	if m.gitBranch != newBranch {
+		t.Errorf("expected gitBranch %q, got %q", newBranch, m.gitBranch)
+	}
+	if m.gitModified != newModified {
+		t.Errorf("expected gitModified %v, got %v", newModified, m.gitModified)
+	}
+	if cmd != nil {
+		t.Errorf("expected nil cmd, got %v", cmd)
+	}
+}
+
+func TestGitTickUpdate(t *testing.T) {
+	m := initialModel(false, false)
+
+	// Simulate gitTickMsg
+	msg := gitTickMsg{}
+
+	_, cmd := m.Update(msg)
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd for gitTickMsg")
+	}
+
+	// We expect a batch command containing checkGitStatus and doGitTick
+	// We can't easily introspect the batch, but we can at least ensure it's not nil.
+}
+
+func TestCheckGitStatus(t *testing.T) {
+	cmd := checkGitStatus()
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd for checkGitStatus")
+	}
+
+	msg := cmd()
+	if _, ok := msg.(gitStatusMsg); !ok {
+		t.Errorf("expected gitStatusMsg, got %T", msg)
+	}
+}
+
+func TestResponseMsgTriggersGitStatusUpdate(t *testing.T) {
+	m := initialModel(false, false)
+	msg := responseMsg{text: "some output", isShell: true}
+
+	_, cmd := m.Update(msg)
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd for responseMsg")
+	}
+
+	// We can't easily verify it's checkGitStatus, but we can call it and check its type
+	innerMsg := cmd()
+	if _, ok := innerMsg.(gitStatusMsg); !ok {
+		t.Errorf("expected gitStatusMsg, got %T", innerMsg)
+	}
+}

--- a/pkg/sdk/git_tools.go
+++ b/pkg/sdk/git_tools.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 
 	"google.golang.org/adk/tool"
 )
@@ -24,6 +25,29 @@ func runGitCommand(dir string, args ...string) (string, error) {
 	}
 
 	return stdout.String(), nil
+}
+
+type GitInfo struct {
+	Branch   string
+	Modified bool
+}
+
+func GetGitInfo(dir string) (GitInfo, error) {
+	if dir == "" {
+		dir = "."
+	}
+	branch, err := runGitCommand(dir, "rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil {
+		return GitInfo{}, err
+	}
+
+	status, err := runGitCommand(dir, "status", "--porcelain")
+	modified := false
+	if err == nil && len(strings.TrimSpace(status)) > 0 {
+		modified = true
+	}
+
+	return GitInfo{Branch: strings.TrimSpace(branch), Modified: modified}, nil
 }
 
 type GitCommitArgs struct {


### PR DESCRIPTION
Fixes #9 by adding dynamic updates to the status bar for git branch and dirty status. The git logic was refactored into the SDK, and updates are triggered periodically (every 10s) as well as after shell commands and agent responses. Comprehensive unit tests have been added and UI stability was verified.